### PR TITLE
Support new WebSocket API

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,5 +1,5 @@
 
-val http4sVersion   = "0.23.0"
+val http4sVersion   = "0.23.5"
 val natchezVersion  = "0.1.5"
 val scala212Version = "2.12.12"
 val scala213Version = "2.13.5"
@@ -69,6 +69,7 @@ lazy val http4s = project
       "org.tpolecat" %% "natchez-core"  % natchezVersion,
       "org.http4s"   %% "http4s-core"   % http4sVersion,
       "org.http4s"   %% "http4s-client" % http4sVersion,
+      "org.http4s"   %% "http4s-server" % http4sVersion,
     )
   )
 

--- a/modules/docs/src/main/paradox/index.md
+++ b/modules/docs/src/main/paradox/index.md
@@ -17,7 +17,7 @@ See below, then check out the `examples/` module in the repo for a working examp
 
 ## Tracing HttpRoutes
 
-Here is the basic pattern.
+Here is the basic pattern for HTTP applications **without WebSockets**. For the WebSocket variation see below.
 
 - Construct `HttpRoutes` in abstract `F` with a `Trace` constraint.
 - Lift it into our `EntryPoint`'s `F`, which has _no_ `Trace` constraint.
@@ -93,7 +93,6 @@ def mkRoutes2[F[_]](ep: EntryPoint[F])(
   ep.liftT(NatchezMiddleware.server(mkTracedRoutes)) // type arguments are inferred as above
 ```
 
-
 ## Client Middleware
 
 `NatchezMiddleware.client(<client>)` adds a span called `http4s-client-request` around outgoing requests,
@@ -104,6 +103,55 @@ with the following fields.
 | `client.http.method`      | String     | `"GET"`, `"PUT"`, etc. |
 | `client.http.url`         | String     | request URI            |
 | `client.http.status_code` | String (!) | `"200"`, `"403"`, etc. |
+
+## Tracing HttpRoutes with WebSockets
+
+The basic pattern for HTTP applications with WebSockets is analogous to the HTTP-only case above, but instead of `HttpRoutes` we are lifting functions `WebSocketBuilder2 => HttpRoutes`, which is one `map` away from what your pass to your server builder's `withHttpWebSocketApp` method.
+
+- Construct a `WebSocketBuilder2 => HttpRoutes` in abstract `F` with a `Trace` constraint.
+- Lift it into our `EntryPoint`'s `F`, which has _no_ `Trace` constraint.
+
+```scala mdoc:reset
+// Nothing new here
+import cats.effect.MonadCancel
+import natchez.{ EntryPoint, Trace }
+import org.http4s.HttpRoutes
+import org.http4s.server.websocket.WebSocketBuilder2
+
+// This import provides `wsLiftT`, used below.
+import natchez.http4s.implicits._
+
+// Our routes constructor is parametric in its effect, which has (at least) a
+// `Trace` constraint. This means all our handlers will be in the same F and
+// will have tracing available.
+def mkTracedRoutes[F[_]: Trace]: WebSocketBuilder2[F] => HttpRoutes[F] =
+  ???
+
+// Given an EntryPoint in F, with (at least) `MonadCancel[F, Throwable]` but
+// WITHOUT a Trace constraint, we can lift `mkTracedRoutes` into F.
+def mkRoutes[F[_]](ep: EntryPoint[F])(
+  implicit ev: MonadCancel[F, Throwable]
+): WebSocketBuilder2[F] => HttpRoutes[F] =
+  ep.wsLiftT(mkTracedRoutes)
+```
+
+And analogously with `wsLiftR` for the `Resource` case:
+
+```scala mdoc
+import cats.Defer
+import cats.effect.Resource
+
+def mkTracedRoutesResource[F[_]: Trace]: Resource[F, WebSocketBuilder2[F] => HttpRoutes[F]] =
+  ???
+
+// Note that liftR also requires Defer[F]
+def mkRoutesResource[F[_]](ep: EntryPoint[F])(
+  implicit ev: MonadCancel[F, Throwable]
+): Resource[F, WebSocketBuilder2[F] => HttpRoutes[F]] =
+  ep.wsLiftR(mkTracedRoutesResource)
+```
+
+As with the HTTP-only case above, the trick here is that `wsLiftT/R` will infer `F` as `Kleisli` and you won't normally need to mention it in your code.
 
 ## Limitations
 

--- a/modules/examples/src/main/scala/Common.scala
+++ b/modules/examples/src/main/scala/Common.scala
@@ -5,7 +5,7 @@
 package example
 
 import cats._
-import cats.effect._
+import cats.effect.{ Trace => _, _ }
 import cats.syntax.all._
 import io.jaegertracing.Configuration.ReporterConfiguration
 import io.jaegertracing.Configuration.SamplerConfiguration

--- a/modules/http4s/src/main/scala/natchez/http4s/syntax/EntryPointOps.scala
+++ b/modules/http4s/src/main/scala/natchez/http4s/syntax/EntryPointOps.scala
@@ -6,6 +6,7 @@ package natchez.http4s.syntax
 
 import cats.~>
 import cats.data.{ Kleisli, OptionT }
+import cats.data.Kleisli.applyK
 import cats.effect.MonadCancel
 import cats.implicits._
 import natchez.{ EntryPoint, Kernel, Span }
@@ -13,6 +14,7 @@ import org.http4s.HttpRoutes
 import cats.effect.Resource
 import natchez.TraceValue
 import cats.Monad
+import org.http4s.server.websocket.WebSocketBuilder2
 
 trait EntryPointOps[F[_]] { outer =>
 
@@ -21,24 +23,17 @@ trait EntryPointOps[F[_]] { outer =>
   /**
    * Given an entry point and HTTP Routes in Kleisli[F, Span[F], *] return routes in F. A new span
    * is created with the URI path as the name, either as a continuation of the incoming trace, if
-   * any, or as a new root. This can likely be simplified.
+   * any, or as a new root.
    */
   def liftT(routes: HttpRoutes[Kleisli[F, Span[F], *]])(
     implicit ev: MonadCancel[F, Throwable]
   ): HttpRoutes[F] =
     Kleisli { req =>
-      type G[A]  = Kleisli[F, Span[F], A]
-      val lift   = new (F ~> G) {
-        def apply[A](fa: F[A]) = Kleisli(_ => fa)
-      }
       val kernel = Kernel(req.headers.headers.map(h => (h.name.toString -> h.value)).toMap)
       val spanR  = self.continueOrElseRoot(req.uri.path.toString, kernel)
       OptionT {
         spanR.use { span =>
-          val lower = new (G ~> F) {
-            def apply[A](fa: G[A]) = fa(span)
-          }
-          routes.run(req.mapK(lift)).mapK(lower).map(_.mapK(lower)).value
+          routes.run(req.mapK(lift)).mapK(applyK(span)).map(_.mapK(applyK(span))).value
         }
       }
     }
@@ -52,21 +47,48 @@ trait EntryPointOps[F[_]] { outer =>
   def liftR(routes: Resource[Kleisli[F, Span[F], *], HttpRoutes[Kleisli[F, Span[F], *]]])(
     implicit ev: MonadCancel[F, Throwable]
   ): Resource[F, HttpRoutes[F]] =
-    routes.map(liftT).mapK(
-      new (Kleisli[F, Span[F], *] ~> F) {
-        def apply[A](fa: Kleisli[F, Span[F], A]) =
-          fa.run {
-            new Span[F] {
-              val kernel = Kernel(Map.empty).pure[F]
-              def put(fields: (String, TraceValue)*) = Monad[F].unit
-              def span(name: String) = Monad[Resource[F, *]].pure(this)
-              def traceId = Monad[F].pure(None)
-              def traceUri = Monad[F].pure(None)
-              def spanId = Monad[F].pure(None)
-            }
-          }
-      }
-    )
+    routes.map(liftT).mapK(lower)
+
+  /**
+   * Given an entry point and a function from `WebSocketBuilder2` to HTTP Routes in
+   * Kleisli[F, Span[F], *] return a function from `WebSocketBuilder2` to routes in F. A new span
+   * is created with the URI path as the name, either as a continuation of the incoming trace, if
+   * any, or as a new root.
+   */
+  def wsLiftT(
+    routes: WebSocketBuilder2[Kleisli[F, Span[F], *]] => HttpRoutes[Kleisli[F, Span[F], *]]
+  )(implicit ev: MonadCancel[F, Throwable]): WebSocketBuilder2[F] => HttpRoutes[F] = wsb =>
+    liftT(routes(wsb.imapK(lift)(lower)))
+
+  /**
+   * Lift a `WebSocketBuilder2 => HttpRoutes`-yielding resource that consumes `Span`s into the bare
+   * effect. We do this by ignoring any tracing that happens during allocation and freeing of the
+   * `HttpRoutes` resource. The reasoning is that such a resource typically lives for the lifetime
+   * of the application and it's of little use to keep a span open that long.
+   */
+  def wsLiftR(
+    routes: Resource[Kleisli[F, Span[F], *], WebSocketBuilder2[Kleisli[F, Span[F], *]] => HttpRoutes[Kleisli[F, Span[F], *]]]
+  )(implicit ev: MonadCancel[F, Throwable]): Resource[F, WebSocketBuilder2[F] => HttpRoutes[F]] =
+    routes.map(wsLiftT).mapK(lower)
+
+  private val lift: F ~> Kleisli[F, Span[F], *] =
+    Kleisli.liftK
+
+  private def lower(implicit ev: Monad[F]): Kleisli[F, Span[F], *] ~> F =
+    new (Kleisli[F, Span[F], *] ~> F) {
+      def apply[A](fa: Kleisli[F, Span[F], A]) =
+        fa.run(dummySpan)
+    }
+
+  private def dummySpan(implicit ev: Monad[F]): Span[F] =
+    new Span[F] {
+      val kernel = Kernel(Map.empty).pure[F]
+      def put(fields: (String, TraceValue)*) = Monad[F].unit
+      def span(name: String) = Monad[Resource[F, *]].pure(this)
+      def traceId = Monad[F].pure(None)
+      def traceUri = Monad[F].pure(None)
+      def spanId = Monad[F].pure(None)
+    }
 
 }
 


### PR DESCRIPTION
This adds support for lifting functions `WebSocketBuilder2 => HttpApp` for interop wit the new `.withHttpWebSocketApp` convention for server builders, and also simplifies the lifting/lowering implementation for `HttpApp`.