### PR TITLE
Add span name and span options parameters

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,4 @@
-ThisBuild / tlBaseVersion := "0.5"
+ThisBuild / tlBaseVersion := "0.6"
 
 val http4sVersion   = "0.23.17"
 val natchezVersion  = "0.3.0"

--- a/modules/http4s/src/main/scala/natchez/http4s/syntax/EntryPointOps.scala
+++ b/modules/http4s/src/main/scala/natchez/http4s/syntax/EntryPointOps.scala
@@ -23,6 +23,8 @@ import org.typelevel.ci.CIString
  * @define isKernelHeader should an HTTP header be passed to Kernel or not
  *
  * @define spanName compute the span name from the request
+ *
+ * @define spanOptions options used in span creation
  */
 trait EntryPointOps[F[_]] { outer =>
 

--- a/modules/http4s/src/main/scala/natchez/http4s/syntax/EntryPointOps.scala
+++ b/modules/http4s/src/main/scala/natchez/http4s/syntax/EntryPointOps.scala
@@ -21,6 +21,8 @@ import org.typelevel.ci.CIString
  *         are passed to Kernel by default.
  *
  * @define isKernelHeader should an HTTP header be passed to Kernel or not
+ *
+ * @define spanName compute the span name from the request
  */
 trait EntryPointOps[F[_]] { outer =>
 
@@ -28,16 +30,20 @@ trait EntryPointOps[F[_]] { outer =>
 
   /**
    * Given an entry point and HTTP Routes in Kleisli[F, Span[F], *] return routes in F. A new span
-   * is created with the URI path as the name, either as a continuation of the incoming trace, if
+   * is created with by default the URI path as the name, either as a continuation of the incoming trace, if
    * any, or as a new root.
    *
    * @note $excludedHeaders
    *
    * @param isKernelHeader $isKernelHeader
+   * @param spanName $spanName
+   * @param spanOptions $spanOptions
    */
   def liftT(
     routes: HttpRoutes[Kleisli[F, Span[F], *]],
-    isKernelHeader: CIString => Boolean = name => !EntryPointOps.ExcludedHeaders.contains(name)
+    isKernelHeader: CIString => Boolean = name => !EntryPointOps.ExcludedHeaders.contains(name),
+    spanName: org.http4s.Request[F] => String = _.uri.path.toString,
+    spanOptions: Span.Options = Span.Options.Defaults,
   )(implicit ev: MonadCancel[F, Throwable]): HttpRoutes[F] =
     Kleisli { req =>
       val kernelHeaders = req.headers.headers
@@ -47,7 +53,7 @@ trait EntryPointOps[F[_]] { outer =>
         .toMap
 
       val kernel = Kernel(kernelHeaders)
-      val spanR  = self.continueOrElseRoot(req.uri.path.toString, kernel)
+      val spanR  = self.continueOrElseRoot(spanName(req), kernel, spanOptions)
       OptionT {
         spanR.use { span =>
           routes.run(req.mapK(lift)).mapK(applyK(span)).map(_.mapK(applyK(span))).value
@@ -83,9 +89,11 @@ trait EntryPointOps[F[_]] { outer =>
    */
   def wsLiftT(
     routes: WebSocketBuilder2[Kleisli[F, Span[F], *]] => HttpRoutes[Kleisli[F, Span[F], *]],
-    isKernelHeader: CIString => Boolean = name => !EntryPointOps.ExcludedHeaders.contains(name)
-  )(implicit ev: MonadCancel[F, Throwable]): WebSocketBuilder2[F] => HttpRoutes[F] = wsb =>
-    liftT(routes(wsb.imapK(lift)(Span.dropTracing)), isKernelHeader)
+    isKernelHeader: CIString => Boolean = name => !EntryPointOps.ExcludedHeaders.contains(name),
+    spanName: org.http4s.Request[F] => String = _.uri.path.toString,
+    spanOptions: Span.Options = Span.Options.Defaults
+   )(implicit ev: MonadCancel[F, Throwable]): WebSocketBuilder2[F] => HttpRoutes[F] = wsb =>
+    liftT(routes(wsb.imapK(lift)(Span.dropTracing)), isKernelHeader, spanName, spanOptions)
 
   /**
    * Lift a `WebSocketBuilder2 => HttpRoutes`-yielding resource that consumes `Span`s into the bare
@@ -99,9 +107,11 @@ trait EntryPointOps[F[_]] { outer =>
    */
   def wsLiftR(
     routes: Resource[Kleisli[F, Span[F], *], WebSocketBuilder2[Kleisli[F, Span[F], *]] => HttpRoutes[Kleisli[F, Span[F], *]]],
-    isKernelHeader: CIString => Boolean = name => !EntryPointOps.ExcludedHeaders.contains(name)
+    isKernelHeader: CIString => Boolean = name => !EntryPointOps.ExcludedHeaders.contains(name),
+    spanName: org.http4s.Request[F] => String = _.uri.path.toString,
+    spanOptions: Span.Options = Span.Options.Defaults
   )(implicit ev: MonadCancel[F, Throwable]): Resource[F, WebSocketBuilder2[F] => HttpRoutes[F]] =
-    routes.map(wsLiftT(_, isKernelHeader)).mapK(Span.dropTracing)
+    routes.map(wsLiftT(_, isKernelHeader, spanName, spanOptions)).mapK(Span.dropTracing)
 
   private val lift: F ~> Kleisli[F, Span[F], *] =
     Kleisli.liftK


### PR DESCRIPTION
I found useful to be able to compute a name for span. One use case is when uris contains ids but we need a name that reflect the endpoint   