### PR TITLE
Add natchez-http4s-mtl: server middleware with Local[F, Span[F]] semantics

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,11 +83,11 @@ jobs:
 
       - name: Make target directories
         if: github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main')
-        run: mkdir -p modules/http4s/.jvm/target modules/http4s/.js/target modules/http4s/.native/target project/target
+        run: mkdir -p modules/mtl/.native/target modules/http4s/.jvm/target modules/http4s/.js/target modules/http4s/.native/target modules/mtl/.js/target modules/mtl/.jvm/target project/target
 
       - name: Compress target directories
         if: github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main')
-        run: tar cf targets.tar modules/http4s/.jvm/target modules/http4s/.js/target modules/http4s/.native/target project/target
+        run: tar cf targets.tar modules/mtl/.native/target modules/http4s/.jvm/target modules/http4s/.js/target modules/http4s/.native/target modules/mtl/.js/target modules/mtl/.jvm/target project/target
 
       - name: Upload target directories
         if: github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main')

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,11 +83,11 @@ jobs:
 
       - name: Make target directories
         if: github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main')
-        run: mkdir -p modules/mtl/.native/target modules/http4s/.jvm/target modules/http4s/.js/target modules/http4s/.native/target modules/mtl/.js/target modules/mtl/.jvm/target project/target
+        run: mkdir -p modules/mtl/.native/target modules/http4s/.jvm/target modules/http4s/.js/target modules/core/.native/target modules/core/.js/target modules/core/.jvm/target modules/http4s/.native/target modules/mtl/.js/target modules/mtl/.jvm/target project/target
 
       - name: Compress target directories
         if: github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main')
-        run: tar cf targets.tar modules/mtl/.native/target modules/http4s/.jvm/target modules/http4s/.js/target modules/http4s/.native/target modules/mtl/.js/target modules/mtl/.jvm/target project/target
+        run: tar cf targets.tar modules/mtl/.native/target modules/http4s/.jvm/target modules/http4s/.js/target modules/core/.native/target modules/core/.js/target modules/core/.jvm/target modules/http4s/.native/target modules/mtl/.js/target modules/mtl/.jvm/target project/target
 
       - name: Upload target directories
         if: github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main')

--- a/.jvmopts
+++ b/.jvmopts
@@ -1,0 +1,4 @@
+
+-Xms1G
+-Xmx4G
+-XX:+UseG1GC

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -23,6 +23,14 @@ pull_request_rules:
   - status-success=Build and Test (ubuntu-latest, 3, temurin@17, rootNative)
   actions:
     merge: {}
+- name: Label core PRs
+  conditions:
+  - files~=^modules/core/
+  actions:
+    label:
+      add:
+      - core
+      remove: []
 - name: Label docs PRs
   conditions:
   - files~=^modules/docs/
@@ -46,4 +54,12 @@ pull_request_rules:
     label:
       add:
       - http4s
+      remove: []
+- name: Label mtl PRs
+  conditions:
+  - files~=^modules/mtl/
+  actions:
+    label:
+      add:
+      - mtl
       remove: []

--- a/build.sbt
+++ b/build.sbt
@@ -8,6 +8,7 @@ val scala3Version           = "3.3.4"
 val slf4jVersion            = "2.0.16"
 val munitCEVersion          = "2.0.0"
 val scalacheckEffectVersion = "2.0.0-M2"
+val catsMtlVersion          = "1.4.0"
 
 ThisBuild / organization := "org.tpolecat"
 ThisBuild / sonatypeCredentialHost := xerial.sbt.Sonatype.sonatypeLegacy
@@ -47,6 +48,7 @@ ThisBuild / crossScalaVersions := Seq(scala212Version, scala213Version, scala3Ve
 
 lazy val root = tlCrossRootProject.aggregate(
   http4s,
+  mtl,
   examples,
   docs
 )
@@ -66,6 +68,23 @@ lazy val http4s = crossProject(JSPlatform, JVMPlatform, NativePlatform)
       "org.tpolecat" %%% "natchez-testkit" % natchezVersion % Test,
     )
   )
+
+lazy val mtl = crossProject(JSPlatform, JVMPlatform, NativePlatform)
+  .crossType(CrossType.Pure)
+  .in(file("modules/mtl"))
+  .settings(commonSettings)
+  .settings(
+    name        := "natchez-http4s",
+    description := "Natchez middleware for http4s with cats-mtl Local[F, Span[F]] semantics.",
+    libraryDependencies ++= Seq(
+      "org.tpolecat"  %%% "natchez-mtl"     % natchezVersion,
+      "org.http4s"    %%% "http4s-core"     % http4sVersion,
+      "org.http4s"    %%% "http4s-server"   % http4sVersion,
+      "org.typelevel" %%% "cats-mtl"        % catsMtlVersion,
+      "org.tpolecat"  %%% "natchez-testkit" % natchezVersion % Test,
+    )
+  )
+  .dependsOn(http4s % "compile->compile;test->test") // TODO limit this dependency so this doesn't pull in the http4s-client
 
 lazy val examples = project
   .in(file("modules/examples"))

--- a/build.sbt
+++ b/build.sbt
@@ -10,7 +10,7 @@ val munitCEVersion          = "2.0.0"
 val scalacheckEffectVersion = "2.0.0-M2"
 
 ThisBuild / organization := "org.tpolecat"
-ThisBuild / tlSonatypeUseLegacyHost := false
+ThisBuild / sonatypeCredentialHost := xerial.sbt.Sonatype.sonatypeLegacy
 ThisBuild / licenses := Seq(("MIT", url("http://opensource.org/licenses/MIT")))
 ThisBuild / homepage := Some(url("https://github.com/tpolecat/natchez-http4s"))
 ThisBuild / developers := List(

--- a/build.sbt
+++ b/build.sbt
@@ -47,11 +47,26 @@ ThisBuild / scalaVersion := scala213Version
 ThisBuild / crossScalaVersions := Seq(scala212Version, scala213Version, scala3Version)
 
 lazy val root = tlCrossRootProject.aggregate(
+  core,
   http4s,
   mtl,
   examples,
   docs
 )
+
+lazy val core = crossProject(JSPlatform, JVMPlatform, NativePlatform)
+  .crossType(CrossType.Pure)
+  .in(file("modules/core"))
+  .settings(commonSettings)
+  .settings(
+    name        := "natchez-http4s-core",
+    description := "Natchez middleware for http4s.",
+    libraryDependencies ++= Seq(
+      "org.tpolecat" %%% "natchez-core"    % natchezVersion,
+      "org.http4s"   %%% "http4s-core"     % http4sVersion,
+    ),
+    tlVersionIntroduced := List("2.12", "2.13", "3").map(_ -> "0.6.1").toMap
+  )
 
 lazy val http4s = crossProject(JSPlatform, JVMPlatform, NativePlatform)
   .crossType(CrossType.Pure)
@@ -61,20 +76,19 @@ lazy val http4s = crossProject(JSPlatform, JVMPlatform, NativePlatform)
     name        := "natchez-http4s",
     description := "Natchez middleware for http4s.",
     libraryDependencies ++= Seq(
-      "org.tpolecat" %%% "natchez-core"    % natchezVersion,
-      "org.http4s"   %%% "http4s-core"     % http4sVersion,
       "org.http4s"   %%% "http4s-client"   % http4sVersion,
       "org.http4s"   %%% "http4s-server"   % http4sVersion,
       "org.tpolecat" %%% "natchez-testkit" % natchezVersion % Test,
     )
   )
+  .dependsOn(core)
 
 lazy val mtl = crossProject(JSPlatform, JVMPlatform, NativePlatform)
   .crossType(CrossType.Pure)
   .in(file("modules/mtl"))
   .settings(commonSettings)
   .settings(
-    name        := "natchez-http4s",
+    name        := "natchez-http4s-mtl",
     description := "Natchez middleware for http4s with cats-mtl Local[F, Span[F]] semantics.",
     libraryDependencies ++= Seq(
       "org.tpolecat"  %%% "natchez-mtl"     % natchezVersion,
@@ -82,9 +96,10 @@ lazy val mtl = crossProject(JSPlatform, JVMPlatform, NativePlatform)
       "org.http4s"    %%% "http4s-server"   % http4sVersion,
       "org.typelevel" %%% "cats-mtl"        % catsMtlVersion,
       "org.tpolecat"  %%% "natchez-testkit" % natchezVersion % Test,
-    )
+    ),
+    tlVersionIntroduced := List("2.12", "2.13", "3").map(_ -> "0.6.1").toMap
   )
-  .dependsOn(http4s % "compile->compile;test->test") // TODO limit this dependency so this doesn't pull in the http4s-client
+  .dependsOn(core, http4s % "test->test")
 
 lazy val examples = project
   .in(file("modules/examples"))

--- a/modules/core/src/main/scala/natchez/http4s/DefaultValues.scala
+++ b/modules/core/src/main/scala/natchez/http4s/DefaultValues.scala
@@ -1,0 +1,29 @@
+// Copyright (c) 2021 by Rob Norris
+// This software is licensed under the MIT License (MIT).
+// For more information see LICENSE or https://opensource.org/licenses/MIT
+
+package natchez
+package http4s
+
+import org.http4s.headers.*
+import org.typelevel.ci.*
+
+private[natchez] object DefaultValues {
+  private[natchez] val ExcludedHeaders: Set[CIString] = {
+    val payload = Set(
+      `Content-Length`.name,
+      ci"Content-Type",
+      `Content-Range`.name,
+      ci"Trailer",
+      `Transfer-Encoding`.name,
+    )
+
+    val security = Set(
+      Authorization.name,
+      Cookie.name,
+      `Set-Cookie`.name,
+    )
+
+    payload ++ security
+  }
+}

--- a/modules/http4s/src/main/scala/natchez/http4s/syntax/EntryPointOps.scala
+++ b/modules/http4s/src/main/scala/natchez/http4s/syntax/EntryPointOps.scala
@@ -5,12 +5,13 @@
 package natchez.http4s.syntax
 
 import cats.~>
-import cats.data.{ Kleisli, OptionT }
+import cats.data.{Kleisli, OptionT}
 import cats.data.Kleisli.applyK
 import cats.effect.MonadCancel
-import natchez.{ EntryPoint, Kernel, Span }
+import natchez.{EntryPoint, Kernel, Span}
 import org.http4s.HttpRoutes
 import cats.effect.Resource
+import natchez.http4s.DefaultValues
 import org.http4s.server.websocket.WebSocketBuilder2
 import org.typelevel.ci.CIString
 
@@ -120,26 +121,7 @@ trait EntryPointOps[F[_]] { outer =>
 }
 
 object EntryPointOps {
-  val ExcludedHeaders: Set[CIString] = {
-    import org.http4s.headers._
-    import org.typelevel.ci._
-
-    val payload = Set(
-      `Content-Length`.name,
-      ci"Content-Type",
-      `Content-Range`.name,
-      ci"Trailer",
-      `Transfer-Encoding`.name,
-    )
-
-    val security = Set(
-      Authorization.name,
-      Cookie.name,
-      `Set-Cookie`.name,
-    )
-
-    payload ++ security
-  }
+  val ExcludedHeaders: Set[CIString] = DefaultValues.ExcludedHeaders
 }
 
 trait ToEntryPointOps {

--- a/modules/http4s/src/test/scala/natchez/http4s/InMemory.scala
+++ b/modules/http4s/src/test/scala/natchez/http4s/InMemory.scala
@@ -5,22 +5,27 @@
 package natchez
 package http4s
 
-import cats.data.Kleisli
+import cats.data.{Chain, Kleisli}
 import cats.effect.{IO, MonadCancelThrow}
 import munit.CatsEffectSuite
+import natchez.Span.Options.SpanCreationPolicy
+import natchez.Span.SpanKind
+import org.scalacheck.{Arbitrary, Gen}
+import org.scalacheck.Arbitrary.arbitrary
+import org.typelevel.ci.*
 
 trait InMemorySuite extends CatsEffectSuite {
   type Lineage = InMemory.Lineage
-  val Lineage = InMemory.Lineage
+  val Lineage: InMemory.Lineage.type = InMemory.Lineage
   type NatchezCommand = InMemory.NatchezCommand
-  val NatchezCommand = InMemory.NatchezCommand
+  val NatchezCommand: InMemory.NatchezCommand.type = InMemory.NatchezCommand
 
   trait TraceTest {
     def program[F[_]: MonadCancelThrow: Trace]: F[Unit]
     def expectedHistory: List[(Lineage, NatchezCommand)]
   }
 
-  def traceTest(name: String, tt: TraceTest) = {
+  def traceTest(name: String, tt: TraceTest): Unit = {
     test(s"$name - Kleisli")(
       testTraceKleisli(tt.program[Kleisli[IO, Span[IO], *]](implicitly, _), tt.expectedHistory)
     )
@@ -30,7 +35,7 @@ trait InMemorySuite extends CatsEffectSuite {
   def testTraceKleisli(
       traceProgram: Trace[Kleisli[IO, Span[IO], *]] => Kleisli[IO, Span[IO], Unit],
       expectedHistory: List[(Lineage, NatchezCommand)]
-  ) = testTrace[Kleisli[IO, Span[IO], *]](
+  ): IO[Unit] = testTrace[Kleisli[IO, Span[IO], *]](
     traceProgram,
     root => IO.pure(Trace[Kleisli[IO, Span[IO], *]] -> (k => k.run(root))),
     expectedHistory
@@ -39,13 +44,13 @@ trait InMemorySuite extends CatsEffectSuite {
   def testTraceIoLocal(
       traceProgram: Trace[IO] => IO[Unit],
       expectedHistory: List[(Lineage, NatchezCommand)]
-  ) = testTrace[IO](traceProgram, Trace.ioTrace(_).map(_ -> identity), expectedHistory)
+  ): IO[Unit] = testTrace[IO](traceProgram, Trace.ioTrace(_).map(_ -> identity), expectedHistory)
 
   def testTrace[F[_]](
       traceProgram: Trace[F] => F[Unit],
       makeTraceAndResolver: Span[IO] => IO[(Trace[F], F[Unit] => IO[Unit])],
       expectedHistory: List[(Lineage, NatchezCommand)]
-  ) =
+  ): IO[Unit] =
     InMemory.EntryPoint.create[IO].flatMap { ep =>
       val traced = ep.root("root").use { r =>
         makeTraceAndResolver(r).flatMap { case (traceInstance, resolve) =>
@@ -56,4 +61,71 @@ trait InMemorySuite extends CatsEffectSuite {
         assertEquals(history.toList, expectedHistory)
       }
     }
+
+  // TODO remove if https://github.com/typelevel/natchez/pull/1071 is merged
+  implicit val arbTraceValue: Arbitrary[TraceValue] = Arbitrary {
+    Gen.oneOf(
+      arbitrary[String].map(TraceValue.StringValue(_)),
+      arbitrary[Boolean].map(TraceValue.BooleanValue(_)),
+      arbitrary[Number].map(TraceValue.NumberValue(_)),
+    )
+  }
+
+  // TODO remove if https://github.com/typelevel/natchez/pull/1071 is merged
+  implicit val arbAttribute: Arbitrary[(String, TraceValue)] = Arbitrary {
+    for {
+      key <- arbitrary[String]
+      value <- arbitrary[TraceValue]
+    } yield key -> value
+  }
+
+  // TODO remove if https://github.com/typelevel/natchez/pull/1071 is merged
+  implicit val arbCIString: Arbitrary[CIString] = Arbitrary {
+    Gen.alphaLowerStr.map(CIString(_))
+  }
+
+  // TODO remove if https://github.com/typelevel/natchez/pull/1071 is merged
+  implicit val arbKernel: Arbitrary[Kernel] = Arbitrary {
+    arbitrary[Map[CIString, String]].map(Kernel(_))
+  }
+
+  // TODO remove if https://github.com/typelevel/natchez/pull/1071 is merged
+  implicit val arbSpanCreationPolicy: Arbitrary[SpanCreationPolicy] = Arbitrary {
+    Gen.oneOf(SpanCreationPolicy.Default, SpanCreationPolicy.Coalesce, SpanCreationPolicy.Suppress)
+  }
+
+  // TODO remove if https://github.com/typelevel/natchez/pull/1071 is merged
+  implicit val arbSpanKind: Arbitrary[SpanKind] = Arbitrary {
+    Gen.oneOf(
+      SpanKind.Internal,
+      SpanKind.Client,
+      SpanKind.Server,
+      SpanKind.Producer,
+      SpanKind.Consumer,
+    )
+  }
+
+  // TODO remove if https://github.com/typelevel/natchez/pull/1071 is merged
+  implicit val arbSpanOptions: Arbitrary[Span.Options] = Arbitrary {
+    for {
+      parentKernel <- arbitrary[Option[Kernel]]
+      spanCreationPolicy <- arbitrary[SpanCreationPolicy]
+      spanKind <- arbitrary[SpanKind]
+      links <- arbitrary[List[Kernel]].map(Chain.fromSeq)
+    } yield {
+      links.foldLeft {
+        parentKernel.foldLeft {
+          Span
+            .Options
+            .Defaults
+            .withSpanKind(spanKind)
+            .withSpanCreationPolicy(spanCreationPolicy)
+        }(_.withParentKernel(_))
+      }(_.withLink(_))
+    }
+  }
+
+  val CustomHeaderName = ci"X-Custom-Header"
+  val CorrelationIdName = ci"X-Correlation-Id"
+
 }

--- a/modules/mtl/src/main/scala/natchez/mtl/http4s/syntax/EntryPointOps.scala
+++ b/modules/mtl/src/main/scala/natchez/mtl/http4s/syntax/EntryPointOps.scala
@@ -1,0 +1,134 @@
+// Copyright (c) 2021 by Rob Norris
+// This software is licensed under the MIT License (MIT).
+// For more information see LICENSE or https://opensource.org/licenses/MIT
+
+package natchez.mtl.http4s.syntax
+
+import cats.arrow.FunctionK
+import cats.data.*
+import cats.effect.*
+import cats.mtl.Local
+import cats.~>
+import natchez.Span.SpanKind.Server
+import natchez.{EntryPoint, Kernel, Span}
+import org.http4s.{Http, HttpApp, HttpRoutes, Request}
+import org.typelevel.ci.CIString
+
+trait EntryPointOps[F[_]] { outer =>
+  def self: EntryPoint[F]
+
+  /**
+   * Starts or continues a trace for each request handled by the passed `HttpApp[F]`.
+   *
+   * @param routes the `HttpApp[F]` that handles requests. Each invocation will occur in the scope of a new or continued `Trace[F]`
+   * @param isKernelHeader a function to determine whether a given request header should be included in the `Trace[F]`'s `Kernel`
+   * @param spanName a function to derive the name of the created span from the request being handled.
+   *                 By default, this uses the request method and URI path, although strictly speaking this
+   *                 is not compliant with the OpenTelemetry spec for any URIs with path variables. See Note 5 in the
+   *                 [[https://opentelemetry.io/docs/specs/semconv/attributes-registry/http/#http-attributes Semantic Conventions for HTTP]].
+   * @param spanOptions allows the caller to override the Natchez Span options. By default, this uses the default options with a `Server` span kind.
+   * @return the wrapped `HttpApp[F]`
+   */
+  def liftApp(routes: HttpApp[F],
+              isKernelHeader: CIString => Boolean = name => !natchez.http4s.syntax.EntryPointOps.ExcludedHeaders.contains(name),
+              spanName: Request[F] => String = (req: Request[F]) => s"${req.method} ${req.uri.path}",
+              spanOptions: Span.Options = Span.Options.Defaults.withSpanKind(Server),
+             )
+             (implicit F: MonadCancelThrow[F],
+              L: Local[F, Span[F]],
+             ): HttpApp[F] =
+    liftHttp[F](routes, isKernelHeader, spanName, spanOptions, FunctionK.id)
+
+  /**
+   * Starts or continues a trace for each request handled by the passed `HttpRoutes[F]`.
+   *
+   * When using this method with OpenTelemetry to add tracing to a subset of the routes
+   * handled by your app, be careful to place the traced routes in the lowest priority
+   * when combining them with untraced routes. If the `HttpRoutes[F]` wrapped by this
+   * method are higher priority, traces will be emitted that contain no information,
+   * because [[EntryPoint.continueOrElseRoot(name:String,kernel:natchez\.Kernel)*]]
+   * will be invoked regardless of whether the routes passed to this method actually
+   * handle the request or not.
+   *
+   * For example:
+   * {{{
+   *   def routesToBeTraced: HttpRoutes[F] = ???
+   *   def untracedRoutes: HttpRoutes[F] = ???
+   *
+   *   untracedRoutes <+> entryPoint.liftRoutes(routesToBeTraced)
+   * }}}
+   *
+   * will work as expected, but
+   *
+   * {{{
+   *   entryPoint.liftRoutes(routesToBeTraced) <+> untracedRoutes
+   * }}}
+   *
+   * will not, and the requests handled by `untracedRoutes` will in fact generate
+   * empty traces.
+   *
+   * @param routes the `HttpRoutes[F]` that handles requests. Each invocation will occur in the scope of a new or continued `Trace[F]`
+   * @param isKernelHeader a function to determine whether a given request header should be included in the `Trace[F]`'s `Kernel`
+   * @param spanName a function to derive the name of the created span from the request being handled.
+   *                 By default, this uses the request method and URI path, although strictly speaking this
+   *                 is not compliant with the OpenTelemetry spec for any URIs with path variables. See Note 5 in the
+   *                 [[https://opentelemetry.io/docs/specs/semconv/attributes-registry/http/#http-attributes Semantic Conventions for HTTP]].
+   * @param spanOptions allows the caller to override the Natchez Span options. By default, this uses the default options with a `Server` span kind.
+   * @return the wrapped `HttpRoutes[F]`
+   */
+  def liftRoutes(routes: HttpRoutes[F],
+                 isKernelHeader: CIString => Boolean = name => !natchez.http4s.syntax.EntryPointOps.ExcludedHeaders.contains(name),
+                 spanName: Request[F] => String = (req: Request[F]) => s"${req.method} ${req.uri.path}",
+                 spanOptions: Span.Options = Span.Options.Defaults.withSpanKind(Server),
+                )
+                (implicit F: MonadCancelThrow[F],
+                 L: Local[F, Span[F]],
+                ): HttpRoutes[F] =
+    liftHttp(routes, isKernelHeader, spanName, spanOptions, OptionT.liftK)
+
+  /**
+   * Starts or continues a trace for each request handled by the passed `Http[G, F]`.
+   *
+   * @param routes the `Http[G, F]` that handles requests. Each invocation will occur in the scope of a new or continued `Trace[F]`
+   * @param isKernelHeader a function to determine whether a given request header should be included in the `Trace[F]`'s `Kernel`
+   * @param spanName a function to derive the name of the created span from the request being handled.
+   *                 By default, this uses the request method and URI path, although strictly speaking this
+   *                 is not compliant with the OpenTelemetry spec for any URIs with path variables. See Note 5 in the
+   *                 [[https://opentelemetry.io/docs/specs/semconv/attributes-registry/http/#http-attributes Semantic Conventions for HTTP]].
+   * @param spanOptions allows the caller to override the Natchez Span options. By default, this uses the default options with a `Server` span kind.
+   * @return the wrapped `Http[G, F]`
+   */
+  def liftHttp[G[_]](routes: Http[G, F],
+                     isKernelHeader: CIString => Boolean,
+                     spanName: Request[F] => String,
+                     spanOptions: Span.Options,
+                     fk: F ~> G,
+                    )
+                    (implicit F: MonadCancelThrow[F],
+                     G: MonadCancelThrow[G],
+                     L: Local[G, Span[F]],
+                    ): Http[G, F] =
+    Kleisli { req =>
+      val kernelHeaders =
+        req.headers.headers
+          .collect {
+            case header if isKernelHeader(header.name) => header.name -> header.value
+          }
+          .toMap
+
+      self
+        .continueOrElseRoot(spanName(req), Kernel(kernelHeaders), spanOptions)
+        .mapK(fk)
+        .use(Local[G, Span[F]].scope(routes.run(req)))
+    }
+
+}
+
+trait ToEntryPointOps {
+  implicit def toEntryPointOps[F[_]](ep: EntryPoint[F]): EntryPointOps[F] =
+    new EntryPointOps[F] {
+      val self: EntryPoint[F] = ep
+    }
+}
+
+object entrypoint extends ToEntryPointOps

--- a/modules/mtl/src/main/scala/natchez/mtl/http4s/syntax/EntryPointOps.scala
+++ b/modules/mtl/src/main/scala/natchez/mtl/http4s/syntax/EntryPointOps.scala
@@ -10,6 +10,7 @@ import cats.effect.*
 import cats.mtl.Local
 import cats.~>
 import natchez.Span.SpanKind.Server
+import natchez.http4s.DefaultValues.ExcludedHeaders
 import natchez.{EntryPoint, Kernel, Span}
 import org.http4s.{Http, HttpApp, HttpRoutes, Request}
 import org.typelevel.ci.CIString
@@ -30,7 +31,7 @@ trait EntryPointOps[F[_]] { outer =>
    * @return the wrapped `HttpApp[F]`
    */
   def liftApp(routes: HttpApp[F],
-              isKernelHeader: CIString => Boolean = name => !natchez.http4s.syntax.EntryPointOps.ExcludedHeaders.contains(name),
+              isKernelHeader: CIString => Boolean = name => !ExcludedHeaders.contains(name),
               spanName: Request[F] => String = (req: Request[F]) => s"${req.method} ${req.uri.path}",
               spanOptions: Span.Options = Span.Options.Defaults.withSpanKind(Server),
              )
@@ -77,7 +78,7 @@ trait EntryPointOps[F[_]] { outer =>
    * @return the wrapped `HttpRoutes[F]`
    */
   def liftRoutes(routes: HttpRoutes[F],
-                 isKernelHeader: CIString => Boolean = name => !natchez.http4s.syntax.EntryPointOps.ExcludedHeaders.contains(name),
+                 isKernelHeader: CIString => Boolean = name => !ExcludedHeaders.contains(name),
                  spanName: Request[F] => String = (req: Request[F]) => s"${req.method} ${req.uri.path}",
                  spanOptions: Span.Options = Span.Options.Defaults.withSpanKind(Server),
                 )

--- a/modules/mtl/src/main/scala/natchez/mtl/http4s/syntax/EntryPointOps.scala
+++ b/modules/mtl/src/main/scala/natchez/mtl/http4s/syntax/EntryPointOps.scala
@@ -19,26 +19,69 @@ trait EntryPointOps[F[_]] { outer =>
   def self: EntryPoint[F]
 
   /**
-   * Starts or continues a trace for each request handled by the passed `HttpApp[F]`.
+   * Starts or continues a trace for each request handled by the passed `HttpApp[F]`
+   * using the default [[HttpTracingOptions]].
    *
    * @param routes the `HttpApp[F]` that handles requests. Each invocation will occur in the scope of a new or continued `Trace[F]`
-   * @param isKernelHeader a function to determine whether a given request header should be included in the `Trace[F]`'s `Kernel`
-   * @param spanName a function to derive the name of the created span from the request being handled.
-   *                 By default, this uses the request method and URI path, although strictly speaking this
-   *                 is not compliant with the OpenTelemetry spec for any URIs with path variables. See Note 5 in the
-   *                 [[https://opentelemetry.io/docs/specs/semconv/attributes-registry/http/#http-attributes Semantic Conventions for HTTP]].
-   * @param spanOptions allows the caller to override the Natchez Span options. By default, this uses the default options with a `Server` span kind.
    * @return the wrapped `HttpApp[F]`
    */
-  def liftApp(routes: HttpApp[F],
-              isKernelHeader: CIString => Boolean = name => !ExcludedHeaders.contains(name),
-              spanName: Request[F] => String = (req: Request[F]) => s"${req.method} ${req.uri.path}",
-              spanOptions: Span.Options = Span.Options.Defaults.withSpanKind(Server),
-             )
+  def liftApp(routes: HttpApp[F])
              (implicit F: MonadCancelThrow[F],
               L: Local[F, Span[F]],
              ): HttpApp[F] =
-    liftHttp[F](routes, isKernelHeader, spanName, spanOptions, FunctionK.id)
+    liftApp(routes, HttpTracingOptions[F])
+
+  /**
+   * Starts or continues a trace for each request handled by the passed `HttpApp[F]`.
+   *
+   * @param routes the `HttpApp[F]` that handles requests. Each invocation will occur in the scope of a new or continued `Trace[F]`
+   * @param options the [[HttpTracingOptions]] to apply to each request
+   * @return the wrapped `HttpApp[F]`
+   */
+  def liftApp(routes: HttpApp[F],
+              options: HttpTracingOptions[F])
+             (implicit F: MonadCancelThrow[F],
+              L: Local[F, Span[F]],
+             ): HttpApp[F] =
+    liftHttp(routes, options, FunctionK.id)
+
+  /**
+   * Starts or continues a trace for each request handled by the passed `HttpRoutes[F]`
+   * using the default [[HttpTracingOptions]].
+   *
+   * When using this method with OpenTelemetry to add tracing to a subset of the routes
+   * handled by your app, be careful to place the traced routes in the lowest priority
+   * when combining them with untraced routes. If the `HttpRoutes[F]` wrapped by this
+   * method are higher priority, traces will be emitted that contain no information,
+   * because [[EntryPoint.continueOrElseRoot(name:String,kernel:natchez\.Kernel)*]]
+   * will be invoked regardless of whether the routes passed to this method actually
+   * handle the request or not.
+   *
+   * For example:
+   * {{{
+   *   def routesToBeTraced: HttpRoutes[F] = ???
+   *   def untracedRoutes: HttpRoutes[F] = ???
+   *
+   *   untracedRoutes <+> entryPoint.liftRoutes(routesToBeTraced)
+   * }}}
+   *
+   * will work as expected, but
+   *
+   * {{{
+   *   entryPoint.liftRoutes(routesToBeTraced) <+> untracedRoutes
+   * }}}
+   *
+   * will not, and the requests handled by `untracedRoutes` will in fact generate
+   * empty traces.
+   *
+   * @param routes the `HttpRoutes[F]` that handles requests. Each invocation will occur in the scope of a new or continued `Trace[F]`
+   * @return the wrapped `HttpRoutes[F]`
+   */
+  def liftRoutes(routes: HttpRoutes[F])
+                (implicit F: MonadCancelThrow[F],
+                 L: Local[F, Span[F]],
+                ): HttpRoutes[F] =
+    liftRoutes(routes, HttpTracingOptions[F])
 
   /**
    * Starts or continues a trace for each request handled by the passed `HttpRoutes[F]`.
@@ -69,42 +112,41 @@ trait EntryPointOps[F[_]] { outer =>
    * empty traces.
    *
    * @param routes the `HttpRoutes[F]` that handles requests. Each invocation will occur in the scope of a new or continued `Trace[F]`
-   * @param isKernelHeader a function to determine whether a given request header should be included in the `Trace[F]`'s `Kernel`
-   * @param spanName a function to derive the name of the created span from the request being handled.
-   *                 By default, this uses the request method and URI path, although strictly speaking this
-   *                 is not compliant with the OpenTelemetry spec for any URIs with path variables. See Note 5 in the
-   *                 [[https://opentelemetry.io/docs/specs/semconv/attributes-registry/http/#http-attributes Semantic Conventions for HTTP]].
-   * @param spanOptions allows the caller to override the Natchez Span options. By default, this uses the default options with a `Server` span kind.
+   * @param options the [[HttpTracingOptions]] to apply to each request
    * @return the wrapped `HttpRoutes[F]`
    */
   def liftRoutes(routes: HttpRoutes[F],
-                 isKernelHeader: CIString => Boolean = name => !ExcludedHeaders.contains(name),
-                 spanName: Request[F] => String = (req: Request[F]) => s"${req.method} ${req.uri.path}",
-                 spanOptions: Span.Options = Span.Options.Defaults.withSpanKind(Server),
-                )
+                 options: HttpTracingOptions[F])
                 (implicit F: MonadCancelThrow[F],
                  L: Local[F, Span[F]],
                 ): HttpRoutes[F] =
-    liftHttp(routes, isKernelHeader, spanName, spanOptions, OptionT.liftK)
+    liftHttp(routes, options, OptionT.liftK)
+
+  /**
+   * Starts or continues a trace for each request handled by the passed `Http[G, F]`
+   * using the default [[HttpTracingOptions]].
+   *
+   * @param routes the `Http[G, F]` that handles requests. Each invocation will occur in the scope of a new or continued `Trace[F]`
+   * @return the wrapped `Http[G, F]`
+   */
+  def liftHttp[G[_]](routes: Http[G, F],
+                     fk: F ~> G)
+                    (implicit F: MonadCancelThrow[F],
+                     G: MonadCancelThrow[G],
+                     L: Local[G, Span[F]],
+                    ): Http[G, F] =
+    liftHttp(routes, HttpTracingOptions[F], fk)
 
   /**
    * Starts or continues a trace for each request handled by the passed `Http[G, F]`.
    *
    * @param routes the `Http[G, F]` that handles requests. Each invocation will occur in the scope of a new or continued `Trace[F]`
-   * @param isKernelHeader a function to determine whether a given request header should be included in the `Trace[F]`'s `Kernel`
-   * @param spanName a function to derive the name of the created span from the request being handled.
-   *                 By default, this uses the request method and URI path, although strictly speaking this
-   *                 is not compliant with the OpenTelemetry spec for any URIs with path variables. See Note 5 in the
-   *                 [[https://opentelemetry.io/docs/specs/semconv/attributes-registry/http/#http-attributes Semantic Conventions for HTTP]].
-   * @param spanOptions allows the caller to override the Natchez Span options. By default, this uses the default options with a `Server` span kind.
+   * @param options the [[HttpTracingOptions]] to apply to each request
    * @return the wrapped `Http[G, F]`
    */
   def liftHttp[G[_]](routes: Http[G, F],
-                     isKernelHeader: CIString => Boolean,
-                     spanName: Request[F] => String,
-                     spanOptions: Span.Options,
-                     fk: F ~> G,
-                    )
+                     options: HttpTracingOptions[F],
+                     fk: F ~> G)
                     (implicit F: MonadCancelThrow[F],
                      G: MonadCancelThrow[G],
                      L: Local[G, Span[F]],
@@ -113,12 +155,12 @@ trait EntryPointOps[F[_]] { outer =>
       val kernelHeaders =
         req.headers.headers
           .collect {
-            case header if isKernelHeader(header.name) => header.name -> header.value
+            case header if options.isKernelHeader(header.name) => header.name -> header.value
           }
           .toMap
 
       self
-        .continueOrElseRoot(spanName(req), Kernel(kernelHeaders), spanOptions)
+        .continueOrElseRoot(options.spanName(req), Kernel(kernelHeaders), options.spanOptions)
         .mapK(fk)
         .use(Local[G, Span[F]].scope(routes.run(req)))
     }
@@ -133,3 +175,47 @@ trait ToEntryPointOps {
 }
 
 object entrypoint extends ToEntryPointOps
+
+/**
+ * A class holding the various options available to be set on traces started by [[EntryPointOps]].
+ *
+ * @param isKernelHeader a function to determine whether a given request header should be included in the `Trace[F]`'s `Kernel`
+ * @param spanName a function to derive the name of the created span from the request being handled.
+ *                 By default, this uses the request method and URI path, although strictly speaking this
+ *                 is not compliant with the OpenTelemetry spec for any URIs with path variables. See Note 5 in the
+ *                 [[https://opentelemetry.io/docs/specs/semconv/attributes-registry/http/#http-attributes Semantic Conventions for HTTP]].
+ * @param spanOptions allows the caller to override the Natchez Span options. By default, this uses the default options with a `Server` span kind.
+ */
+class HttpTracingOptions[F[_]] private(val isKernelHeader: CIString => Boolean,
+                                       val spanName: Request[F] => String,
+                                       val spanOptions: Span.Options,
+                                   ) {
+  def withKernelHeaderDiscriminator(f: CIString => Boolean): HttpTracingOptions[F] =
+    new HttpTracingOptions(f, spanName, spanOptions)
+  def withSpanNameBuilder[G[_]](f: Request[G] => String): HttpTracingOptions[G] =
+    new HttpTracingOptions(isKernelHeader, f, spanOptions)
+  def withSpanOptions(options: Span.Options): HttpTracingOptions[F] =
+    new HttpTracingOptions(isKernelHeader, spanName, options)
+  def mapK[G[_]](fk: G ~> F): HttpTracingOptions[G] =
+    this.withSpanNameBuilder(spanName.compose(_.mapK(fk)))
+}
+
+object HttpTracingOptions {
+  /**
+   * Returns the default options for [[EntryPointOps]] functions.
+   *
+   *   - `isKernelHeader` will exclude the headers defined in [[natchez.http4s.DefaultValues.ExcludedHeaders]]
+   *   - `spanName` uses the request method and URI path, although strictly speaking this
+   *                  is not compliant with the OpenTelemetry spec for any URIs with path variables. See Note 5 in the
+   *                  [[https://opentelemetry.io/docs/specs/semconv/attributes-registry/http/#http-attributes Semantic Conventions for HTTP]].
+   *   - `spanOptions` uses Natchez's default span options with a `Server` span kind
+   *
+   * @return the default options for [[EntryPointOps]] functions.
+   */
+  def apply[F[_]]: HttpTracingOptions[F] =
+    new HttpTracingOptions[F](
+      isKernelHeader = !ExcludedHeaders.contains(_),
+      spanName = (req: Request[F]) => s"${req.method} ${req.uri.path}",
+      spanOptions = Span.Options.Defaults.withSpanKind(Server),
+  )
+}

--- a/modules/mtl/src/main/scala/natchez/mtl/http4s/syntax/package.scala
+++ b/modules/mtl/src/main/scala/natchez/mtl/http4s/syntax/package.scala
@@ -1,0 +1,7 @@
+// Copyright (c) 2021 by Rob Norris
+// This software is licensed under the MIT License (MIT).
+// For more information see LICENSE or https://opensource.org/licenses/MIT
+
+package natchez.mtl.http4s
+
+package object syntax extends ToEntryPointOps

--- a/modules/mtl/src/test/scala/natchez/mtl/http4s/syntax/EntryPointOpsSuite.scala
+++ b/modules/mtl/src/test/scala/natchez/mtl/http4s/syntax/EntryPointOpsSuite.scala
@@ -1,0 +1,119 @@
+// Copyright (c) 2021 by Rob Norris
+// This software is licensed under the MIT License (MIT).
+// For more information see LICENSE or https://opensource.org/licenses/MIT
+
+package natchez.mtl.http4s.syntax
+
+import cats.effect.{IO, IOLocal, MonadCancelThrow}
+import cats.mtl.Local
+import cats.syntax.all.*
+import cats.{Applicative, Monoid}
+import munit.{Location, ScalaCheckEffectSuite, TestOptions}
+import natchez.Span.Options.Defaults
+import natchez.Span.Options.SpanCreationPolicy.{Coalesce, Default, Suppress}
+import natchez.Span.SpanKind.Server
+import natchez.http4s.InMemorySuite
+import natchez.http4s.syntax.kernel.*
+import natchez.{EntryPoint, InMemory, Kernel, Span, Trace}
+import natchez.mtl.*
+import org.http4s.dsl.Http4sDsl
+import org.http4s.syntax.all.*
+import org.http4s.{Header, Headers, HttpApp, HttpRoutes, Method, Request}
+import org.scalacheck.effect.PropF
+
+class EntryPointOpsSuite
+  extends InMemorySuite
+    with ScalaCheckEffectSuite {
+
+  // TODO remove if https://github.com/typelevel/natchez/pull/1071 is merged
+  implicit val kernelMonoid: Monoid[Kernel] = Monoid.instance(Kernel(Map.empty), (a, b) => Kernel(a.toHeaders |+| b.toHeaders))
+
+  testLift("liftRoutes uses the kernel from the request to continue or create a new trace") { implicit local: Local[IO, Span[IO]] =>
+    (ep: EntryPoint[IO]) =>
+      _.fold(ep.liftRoutes(httpRoutes[IO]))(so => ep.liftRoutes(httpRoutes[IO], spanOptions = so))
+        .orNotFound
+  }
+
+  testLift("liftApp uses the kernel from the request to continue or create a new trace") { implicit local: Local[IO, Span[IO]] =>
+    (ep: EntryPoint[IO]) =>
+      _.fold(ep.liftApp(httpRoutes[IO].orNotFound))(so => ep.liftApp(httpRoutes[IO].orNotFound, spanOptions = so))
+  }
+
+  private def testLift(options: TestOptions)
+                      (body: Local[IO, Span[IO]] => EntryPoint[IO] => Option[Span.Options] => HttpApp[IO])
+                      (implicit loc: Location): Unit =
+    test(options) {
+      PropF.forAllNoShrinkF { (kernel: Kernel, maybeSpanOptions: Option[Span.Options]) =>
+        val request = Request[IO](
+          method = Method.GET,
+          uri = uri"/hello/some-name",
+          headers = Headers(
+            Header.Raw(CustomHeaderName, "external"),
+            Header.Raw(CorrelationIdName, "id-123")
+          ) ++ kernel.toHttp4sHeaders
+        )
+
+        val expectedHistory = {
+          val requestKernel = Kernel(
+            Map(CustomHeaderName -> "external", CorrelationIdName -> "id-123")
+          ) |+| kernel
+
+          maybeSpanOptions.foldl {
+            List(
+              (Lineage.Root, NatchezCommand.CreateRootSpan("GET /hello/some-name", requestKernel, maybeSpanOptions.getOrElse(Defaults.withSpanKind(Server)))),
+              (Lineage.Root("GET /hello/some-name"), NatchezCommand.CreateSpan("trace request handling", None, Span.Options.Defaults)),
+              (Lineage.Root("GET /hello/some-name"), NatchezCommand.ReleaseSpan("trace request handling")),
+              (Lineage.Root, NatchezCommand.ReleaseRootSpan("GET /hello/some-name"))
+            )
+          } { (acc, options) =>
+            if (options.spanCreationPolicy == Default) acc
+            else
+              acc.filter {
+                case (Lineage.Root("root"), _) => options.spanCreationPolicy == Suppress || options.spanCreationPolicy == Coalesce
+                case _ => false
+              }
+          }
+        }
+
+        InMemory.EntryPoint.create[IO]
+          .flatMap { ep =>
+            IOLocal(Span.noop[IO])
+              .map(EntryPointOpsSuite.catsMtlEffectLocalForIO(_))
+              .flatMap {
+                body(_)(ep)(maybeSpanOptions)
+                  .run(request)
+              }
+              .flatMap(_ => ep.ref.get)
+              .map { history =>
+                assertEquals(history.toList, expectedHistory)
+              }
+          }
+      }
+    }
+
+  private def httpRoutes[F[_] : MonadCancelThrow : Trace]: HttpRoutes[F] = {
+    val dsl = new Http4sDsl[F] {}
+    import dsl.*
+
+    HttpRoutes.of[F] {
+      case GET -> Root / "hello" / "some-name" =>
+        Trace[F].span("trace request handling")(Ok())
+    }
+  }
+
+}
+
+object EntryPointOpsSuite {
+  // TODO should this be added to natchez-mtl until https://github.com/typelevel/cats-effect/issues/3385 is merged?
+  def catsMtlEffectLocalForIO[E](implicit ioLocal: IOLocal[E]): Local[IO, E] =
+    new Local[IO, E] {
+      override def local[A](fa: IO[A])(f: E => E): IO[A] =
+        ioLocal.get.flatMap { initial =>
+          ioLocal.set(f(initial)) >> fa.guarantee(ioLocal.set(initial))
+        }
+
+      override def applicative: Applicative[IO] = IO.asyncForIO
+
+      override def ask[E2 >: E]: IO[E2] = ioLocal.get
+    }
+}

--- a/modules/mtl/src/test/scala/natchez/mtl/http4s/syntax/EntryPointOpsSuite.scala
+++ b/modules/mtl/src/test/scala/natchez/mtl/http4s/syntax/EntryPointOpsSuite.scala
@@ -8,7 +8,7 @@ import cats.arrow.FunctionK
 import cats.effect.{IO, IOLocal, MonadCancelThrow}
 import cats.mtl.Local
 import cats.syntax.all.*
-import cats.{Applicative, Monoid}
+import cats.Applicative
 import munit.{Location, ScalaCheckEffectSuite, TestOptions}
 import natchez.Span.Options.Defaults
 import natchez.Span.Options.SpanCreationPolicy.{Coalesce, Default, Suppress}
@@ -25,9 +25,6 @@ import org.scalacheck.effect.PropF
 class EntryPointOpsSuite
   extends InMemorySuite
     with ScalaCheckEffectSuite {
-
-  // TODO remove if https://github.com/typelevel/natchez/pull/1071 is merged
-  implicit val kernelMonoid: Monoid[Kernel] = Monoid.instance(Kernel(Map.empty), (a, b) => Kernel(a.toHeaders |+| b.toHeaders))
 
   testLift("liftRoutes uses the kernel from the request to continue or create a new trace") { implicit local: Local[IO, Span[IO]] =>
     _.liftRoutes(httpRoutes[IO], _).orNotFound


### PR DESCRIPTION
We've been using a variant of this internally, and it seems to work well, albeit with the caveats described on the `liftRoutes` methods.
